### PR TITLE
Add check to ensure locales exist

### DIFF
--- a/src/Rules/Clean.php
+++ b/src/Rules/Clean.php
@@ -6,6 +6,7 @@ use Closure;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Str;
+use InvalidArgumentException;
 
 class Clean implements ValidationRule
 {
@@ -17,14 +18,33 @@ class Clean implements ValidationRule
     {
         $locales = empty($this->locales) ? [Config::get('app.locale')] : $this->locales;
 
+        $this->ensureLocalesAreValid($locales);
+
         foreach ($locales as $locale) {
-            $profanities = Config::get('profanify-'.$locale);
+            $profanities = Config::get('profanify-' . $locale);
             $tolerated = Config::get('profanify-tolerated');
 
             if (Str::contains(Str::lower(Str::remove($tolerated, $value)), $profanities)) {
                 $fail(trans('message'))->translate([
                     'attribute' => $attribute,
                 ], $locale);
+            }
+        }
+    }
+
+    /**
+     * Check that a config file exists for each locale. If one of the locales
+     * is invalid, then throw an exception.
+     */
+    protected function ensureLocalesAreValid(array $locales): void
+    {
+        foreach ($locales as $locale) {
+            if (!is_string($locale)) {
+                throw new InvalidArgumentException('The locale must be a string.');
+            }
+
+            if (!Config::has('profanify-' . $locale)) {
+                throw new InvalidArgumentException("The locale ['{$locale}'] is not supported.");
             }
         }
     }

--- a/tests/CleanTest.php
+++ b/tests/CleanTest.php
@@ -45,3 +45,25 @@ test('different language', function ($word) {
     'shit',
     'bastard',
 ]);
+
+it('throws an exception if one of the locales is not a string', function () {
+    (new Validator(
+        $this->translator,
+        ['name' => 'hello'],
+        ['name' => new Clean([new stdClass()])])
+    )->passes();
+})->throws(
+    exception: InvalidArgumentException::class,
+    exceptionMessage: 'The locale must be a string.'
+);
+
+it('throws an exception if one of the locales does not have a profanity config list', function () {
+    (new Validator(
+        $this->translator,
+        ['name' => 'hello'],
+        ['name' => new Clean(['en', 'invalid'])])
+    )->passes();
+})->throws(
+    exception: InvalidArgumentException::class,
+    exceptionMessage: 'The locale [\'invalid\'] is not supported.'
+);


### PR DESCRIPTION
Hey @JonPurvis! This PR proposes a small change which checks all the locales passed to the rule are valid.

At the moment, if a locale doesn't exist, the validation rule will pass, which I think could give a false sense of confidence. For example, I might create the rule like so:

```php
