### PR TITLE
Fix Locale value being passed to translator

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Alternatively, instead of passing an array of strings to the rule, you can pass 
 use JonPurvis\Squeaky\Enums\Locale;
 use JonPurvis\Squeaky\Rules\Clean;
 
-'name' => ['required', 'string', 'max:255', new Clean([Locale::English, Locale::Italian])],
+'name' => ['required', 'string', 'max:255', new Clean([Locale::English->value, Locale::Italian->value])],
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Alternatively, instead of passing an array of strings to the rule, you can pass 
 use JonPurvis\Squeaky\Enums\Locale;
 use JonPurvis\Squeaky\Rules\Clean;
 
-'name' => ['required', 'string', 'max:255', new Clean([Locale::English->value, Locale::Italian->value])],
+'name' => ['required', 'string', 'max:255', new Clean([Locale::English, Locale::Italian])],
 ```
 
 

--- a/src/Rules/Clean.php
+++ b/src/Rules/Clean.php
@@ -21,9 +21,10 @@ class Clean implements ValidationRule
 
         $this->ensureLocalesAreValid($locales);
 
-        dd($locales);
-
         foreach ($locales as $locale) {
+
+            dd($locale);
+
             $profanities = Config::get($this->configFileName($locale));
             $tolerated = Config::get('profanify-tolerated');
 

--- a/src/Rules/Clean.php
+++ b/src/Rules/Clean.php
@@ -21,7 +21,7 @@ class Clean implements ValidationRule
 
         $this->ensureLocalesAreValid($locales);
 
-        dd('test');
+        dd($locales);
 
         foreach ($locales as $locale) {
             $profanities = Config::get($this->configFileName($locale));

--- a/src/Rules/Clean.php
+++ b/src/Rules/Clean.php
@@ -23,7 +23,7 @@ class Clean implements ValidationRule
 
         foreach ($locales as $locale) {
 
-            dd($locale);
+            dd($locale->value);
 
             $profanities = Config::get($this->configFileName($locale));
             $tolerated = Config::get('profanify-tolerated');

--- a/src/Rules/Clean.php
+++ b/src/Rules/Clean.php
@@ -21,6 +21,8 @@ class Clean implements ValidationRule
 
         $this->ensureLocalesAreValid($locales);
 
+        dd('test');
+
         foreach ($locales as $locale) {
             $profanities = Config::get($this->configFileName($locale));
             $tolerated = Config::get('profanify-tolerated');

--- a/src/Rules/Clean.php
+++ b/src/Rules/Clean.php
@@ -22,16 +22,13 @@ class Clean implements ValidationRule
         $this->ensureLocalesAreValid($locales);
 
         foreach ($locales as $locale) {
-
-            dd($locale->value);
-
             $profanities = Config::get($this->configFileName($locale));
             $tolerated = Config::get('profanify-tolerated');
 
             if (Str::contains(Str::lower(Str::remove($tolerated, $value)), $profanities)) {
                 $fail(trans('message'))->translate([
                     'attribute' => $attribute,
-                ], $locale);
+                ], $locale instanceof Locale ? $locale->value : $locale);
             }
         }
     }


### PR DESCRIPTION
This PR fixes an issue being caused by passing the Enum directly to the translator, when it should be a string. 