### PR TITLE
Fix bug that wasn't reading the `Locale` enum value correctly

### DIFF
--- a/src/Rules/Clean.php
+++ b/src/Rules/Clean.php
@@ -28,7 +28,7 @@ class Clean implements ValidationRule
             if (Str::contains(Str::lower(Str::remove($tolerated, $value)), $profanities)) {
                 $fail(trans('message'))->translate([
                     'attribute' => $attribute,
-                ], $locale);
+                ], $this->getLocaleValue($locale));
             }
         }
     }
@@ -51,15 +51,21 @@ class Clean implements ValidationRule
     }
 
     /**
+     * Get the locale value expressed as a string.
+     */
+    protected function getLocaleValue(string|Locale $locale): string
+    {
+        return $locale instanceof Locale
+            ? $locale->value
+            : $locale;
+    }
+
+    /**
      * Get the name of the config file for the given locale. If a Locale enum is
      * provided, then use the underlying value.
      */
     protected function configFileName(string|Locale $locale): string
     {
-        $locale = $locale instanceof Locale
-            ? $locale->value
-            : $locale;
-
-        return 'profanify-' . $locale;
+        return 'profanify-' . $this->getLocaleValue($locale);
     }
 }

--- a/tests/CleanTest.php
+++ b/tests/CleanTest.php
@@ -15,7 +15,8 @@ beforeEach(function () {
 it('fails', function ($word) {
     $v = new Validator($this->translator, ['name' => $word], ['name' => new Clean]);
 
-    expect($v->fails())->toBeTrue();
+    expect($v->fails())->toBeTrue()
+        ->and($v->errors()->all())->toBe(['The name field is not clean']);
 })->with([
     'fuck',
     'shit',
@@ -52,6 +53,13 @@ it('passes when using enums', function (Locale $locale) {
 
     expect($v->passes())->toBeTrue();
 })->with(Locale::cases());
+
+it('fails when using enums', function () {
+    $v = new Validator($this->translator, ['name' => 'fuck'], ['name' => new Clean([Locale::English])]);
+
+    expect($v->fails())->toBeTrue()
+        ->and($v->errors()->all())->toBe(['The name field is not clean']);
+});
 
 it('throws an exception if one of the locales is not a string or enum', function () {
     (new Validator(


### PR DESCRIPTION
Hey @JonPurvis! This PR fixes the bug I introduced recently because I hadn't handled passing a `Locale` enum to the validation error message.

This fix appears to be working, and there are some tests covering the generated messages. But please give me a shout if there's anything you'd like me to change! 😄